### PR TITLE
fix: reset save map variable before saving

### DIFF
--- a/comum/salvar-na-cidade.pm
+++ b/comum/salvar-na-cidade.pm
@@ -1,5 +1,7 @@
 macro salvarNaCidade {
     call pararDeAtacar
+    release definirVariavelSaveMap
+    $saveMap = undef
     do conf lockMap none
     if (&config(master) =~ /Valhalla/ ) {
         do conf -f saveMap_sequenciaPraArmazenar r1 r0


### PR DESCRIPTION
## Summary
- reset `$saveMap` and restart automacro at the start of `salvarNaCidade`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684fe200de4483258f1afda948a95ccc