### PR TITLE
Corrige posição da Kafra em Izlude

### DIFF
--- a/comum/salvar-na-cidade.pm
+++ b/comum/salvar-na-cidade.pm
@@ -65,7 +65,7 @@ macro salvarNaCidade {
         }
         case (=~ /izlude/i ) {
             do conf -f saveMap_desejado izlude
-            do conf -f saveMap_posicaoKafra 134 88
+            do conf -f saveMap_posicaoKafra 128 148
             do conf -f saveMap_posicaoNpcVenda izlude 105 99
             do conf -f saveMap_posicaoNpcPraPocao izlude_in 115 61
         }


### PR DESCRIPTION
## Summary
- corrigir coordenadas da Kafra em Izlude no arquivo `salvar-na-cidade.pm`

## Testing
- `perl -c comum/salvar-na-cidade.pm` *(fails: Can't modify do "file" in undef operator)*

------
https://chatgpt.com/codex/tasks/task_e_685136d9c0b8832597713beb82deba61