### PR TITLE
Improve shipwreck macros with progress tracking

### DIFF
--- a/comum/barco-naufragado.pm
+++ b/comum/barco-naufragado.pm
@@ -18,6 +18,7 @@ automacro Inicio_Barco_Naufragado {
         log Tutorial - Falando com o NPC correto ID 3411
         do nl
         do talk 2 Injured Passenger#2 c c c
+        do conf -f barco_naufragado_step 1
         log Tutorial - Esperando mudança de mapa
         pause 5
         do move 57 12
@@ -27,18 +28,61 @@ automacro Inicio_Barco_Naufragado {
 automacro Barco_izlude0 {
     exclusive 1
     BaseLevel = 1
-    InMap int_land, int_land01, int_land02, int_land03, int_land04 
+    InMap int_land, int_land01, int_land02, int_land03, int_land04
     QuestActive 21001
+    ConfigKeyNotExist barco_naufragado_step
     call {
-        log Tutorial - primeira_Parte
+        do conf -f barco_naufragado_step 1
+    }
+}
+
+automacro Barco_izlude0_passo1 {
+    exclusive 1
+    BaseLevel = 1
+    QuestActive 21001
+    ConfigKey barco_naufragado_step 1
+    InMap int_land, int_land01, int_land02, int_land03, int_land04
+    call {
+        log Tutorial - primeira_parte
         do talknpc 78 103 c r0 c
-        pause 1
+        do conf barco_naufragado_step 2
+    }
+}
+
+automacro Barco_izlude0_passo2 {
+    exclusive 1
+    BaseLevel = 1
+    QuestActive 21001
+    ConfigKey barco_naufragado_step 2
+    InMap int_land, int_land01, int_land02, int_land03, int_land04
+    call {
         log Tutorial - segunda_parte
+        pause 1
         do talknpc 73 100 r0
+        do conf barco_naufragado_step 3
+    }
+}
+
+automacro Barco_izlude0_passo3 {
+    exclusive 1
+    BaseLevel = 1
+    QuestActive 21001
+    ConfigKey barco_naufragado_step 3
+    InMap int_land, int_land01, int_land02, int_land03, int_land04
+    call {
         log Tutorial - terceira_parte
         do move 69 74
         do talknpc 58 69
-        call voltarAtacar        
+        do conf barco_naufragado_step concluido
+        call voltarAtacar
+    }
+}
+
+automacro Barco_izlude0_limparVariaveis {
+    QuestInactive 21001
+    ConfigKey barco_naufragado_step concluido
+    call {
+        do conf barco_naufragado_step none
     }
 }
 


### PR DESCRIPTION
## Summary
- record progress in `barco_naufragado_step`
- split `Barco_izlude0` into step-based automacros
- reset state once the quest finishes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851ac74aea0832583dc4ff0ee4d1d7a